### PR TITLE
Don't do component validation when ESP_IDF_DISABLE_COMPONENT_VALIDATION is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ endforeach()
 # Only run validation for the main project, not subprojects like bootloader
 idf_build_get_property(bootloader_build BOOTLOADER_BUILD)
 idf_build_get_property(esp_tee_build ESP_TEE_BUILD)
-if(NOT bootloader_build AND NOT esp_tee_build)
+if(NOT $ENV{ESP_IDF_DISABLE_COMPONENT_VALIDATION} AND NOT bootloader_build AND NOT esp_tee_build)
     include("${CMAKE_CURRENT_LIST_DIR}/tools/cmake/component_validation.cmake")
     __component_validation_run_checks()
 endif()


### PR DESCRIPTION
This PR improves CMake time by not doing the expensive component validation checks on every build when `ESP_IDF_DISABLE_COMPONENT_VALIDATION=1` is set.