### PR TITLE
esp_https_ota_begin(): handle HttpStatus_PartialContent-code 206

### DIFF
--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -135,6 +135,13 @@ static esp_err_t _http_handle_response_code(esp_https_ota_t *https_ota_handle, i
     } else if (status_code >= HttpStatus_InternalError) {
         ESP_LOGE(TAG, "Server error (%d)", status_code);
         return ESP_FAIL;
+    } else if (https_ota_handle->binary_file_len > 0
+#if CONFIG_ESP_HTTPS_OTA_ENABLE_PARTIAL_DOWNLOAD
+        && !https_ota_handle->partial_http_download
+#endif
+        && status_code != HttpStatus_PartialContent) {
+        ESP_LOGE(TAG, "Requested range header ignored by server");
+        return ESP_ERR_HTTP_RANGE_NOT_SATISFIABLE;
     }
 
     char upgrade_data_buf[256];


### PR DESCRIPTION
## Description

**Summary**

This PR implements `206 Partial Content` in `esp_https_ota_begin()`.

**Issue**

Currently the esp-idf implementation ignores whether the server supports or doesn't support range requests. If OTA is resumed and the server responds `200 OK` instead of `206 Partial Content`, the OTA will download the image starting at byte 0 but resume writing in flash (after last index when it aborted).

**How to reproduce:**

1. serve the OTA image with `python -m http.server 8000`; at the time of writing `http.server` with Python `3.13` does not support range requests (lets call this server `A`)
2. start OTA
3. at approx. 15% kill the connection: `sudo ss --kill --option state established "sport = :8000"`
4. observe that OTA resumes
5. wait until OTA reaches 100%
6. observe that OTA goes beyond 100% up to 115% and integrity check fails

## Testing

**Simple resumption scenario**

1. apply this PR
2. serve the OTA image with flask: `python -m flask --app server run --port 8000 --host 0.0.0.0`; `server.py` script not provided here (lets call this server `B`))
3. start OTA
4. at approx. 15% kill the connection: `sudo ss --kill --option state established "sport = :8000"`
5. observe that OTA resumes from about 15%
6. wait until OTA reaches 100%
7. observe that OTA does not go beyond 100% and integrity check succeeds


**Hypothetic resumption scenario**

1. apply this PR
2. serve the OTA image with server `A`
3. start OTA
4. at approx. 15% kill server `A` and start server `B`
5. observe that OTA resumption starts again from 0%
6. wait until OTA reaches 100%
7. observe that OTA does not go beyond 100% and integrity check succeeds
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.