### PR TITLE
fix(cmake): fix "IMPORTED_LOCATION not set for imported target" CMake errors by setting dummy locations

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -286,6 +286,8 @@ function(__build_init idf_path)
     # Create the build target, to which the ESP-IDF build properties, dependencies are attached to.
     # Must be global so as to be accessible from any subdirectory in custom projects.
     add_library(__idf_build_target STATIC IMPORTED GLOBAL)
+    # Set the IMPORTED_LOCATION property to avoid errors on IDE codemodel queries with CMake >=4.2
+    set_property(TARGET __idf_build_target PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/dummy.a")
 
     # Set the Python path (which may be passed in via -DPYTHON=) and store in a build property
     set_default(PYTHON "python")

--- a/tools/cmake/component.cmake
+++ b/tools/cmake/component.cmake
@@ -167,6 +167,8 @@ function(__component_add component_dir prefix component_source)
     if(NOT component_target IN_LIST component_targets)
         if(NOT TARGET ${component_target})
             add_library(${component_target} STATIC IMPORTED)
+            # Set the IMPORTED_LOCATION property to avoid errors on IDE codemodel queries with CMake >=4.2
+            set_property(TARGET ${component_target} PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/dummy.a")
         endif()
         idf_build_set_property(__COMPONENT_TARGETS ${component_target} APPEND)
     else()


### PR DESCRIPTION
esp-idf uses imported targets as dummy targets that are never linked. Previous CMake versions would ignore these and not error on unset IMPORTED_LOCATION if they are never actually linked. Newer CMake (>4.2) complains, so set a dummy location that would error when actually linked, which silences the error.

The errors didn't actually break the build, but slowed down the configure step.

The issue is triggered by `${CMAKE_BUILD_DIR}/.cmake/api/v1/query/codemodel-v2` being present during the build. CMake >4.2 now includes imported target information in codemodel queries, and many imported targets created by esp-idf do not have imported locations set, which breaks the query. These queries are usually created by IDEs like qt creator.