### PR TITLE
Fix "IMPORTED_LOCATION not set for imported target" CMake errors during codemodel-v2 api queries with CMake 4.2

### DIFF
--- a/tools/cmake/build.cmake
+++ b/tools/cmake/build.cmake
@@ -286,6 +286,8 @@ function(__build_init idf_path)
     # Create the build target, to which the ESP-IDF build properties, dependencies are attached to.
     # Must be global so as to be accessible from any subdirectory in custom projects.
     add_library(__idf_build_target STATIC IMPORTED GLOBAL)
+    # Set the IMPORTED_LOCATION property to avoid errors on IDE codemodel queries with CMake >=4.2
+    set_property(TARGET __idf_build_target PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/dummy.a")
 
     # Set the Python path (which may be passed in via -DPYTHON=) and store in a build property
     set_default(PYTHON "python")

--- a/tools/cmake/component.cmake
+++ b/tools/cmake/component.cmake
@@ -167,6 +167,8 @@ function(__component_add component_dir prefix component_source)
     if(NOT component_target IN_LIST component_targets)
         if(NOT TARGET ${component_target})
             add_library(${component_target} STATIC IMPORTED)
+            # Set the IMPORTED_LOCATION property to avoid errors on IDE codemodel queries with CMake >=4.2
+            set_property(TARGET ${component_target} PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/dummy.a")
         endif()
         idf_build_set_property(__COMPONENT_TARGETS ${component_target} APPEND)
     else()


### PR DESCRIPTION
esp-idf uses `IMPORTED` targets extensively for internal bookkeeping, but most of these are never linked into a binary, so esp-idf never sets the `IMPORTED_LOCATION` property.

CMake 4.2 and later now include `IMPORTED` target information in codemodel-v2 api queries (which are often used by IDEs to gather information about a CMake project), which causes CMake to print a non-fatal error for every `IMPORTED` target without an `IMPORTED_LOCATION` property.

Upstream PR: https://github.com/espressif/esp-idf/pull/18103

## Testcase

- Create an esp-idf example application
- Build it with `idf.py build` (works)
- Run `install -D /dev/null build/.cmake/api/v1/query/codemodel-v2` to trigger a codemodel-v2 api query on next build
- Run `idf.py reconfigure` (breaks)
- Observe the following errors:

```
-- Configuring done (2.9s)
-- Generating done (0.2s)
CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_trace".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_trace".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_update".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_app_update".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader_support".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bootloader_support".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bt".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_bt".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cmock".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cmock".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_console".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_console".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cxx".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_cxx".

...

CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_xtensa".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "___idf_xtensa".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "__idf_build_target".


CMake Error in CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "__idf_build_target".


-- Build files have been written to: /tmp/tmp.GWBrOKTmsz/build
```
