### PR TITLE
Set CMake CACHE variables for mbedtls correctly

### DIFF
--- a/components/mbedtls/CMakeLists.txt
+++ b/components/mbedtls/CMakeLists.txt
@@ -113,11 +113,11 @@ if(CONFIG_MBEDTLS_CERTIFICATE_BUNDLE)
 endif()
 
 # Only build mbedtls libraries
-set(ENABLE_TESTING CACHE BOOL OFF)
-set(ENABLE_PROGRAMS CACHE BOOL OFF)
+set(ENABLE_TESTING OFF CACHE BOOL "mbedtls: enable testing")
+set(ENABLE_PROGRAMS OFF CACHE BOOL "mbedtls: enable programs")
 
 # Use pre-generated source files in mbedtls repository
-set(GEN_FILES CACHE BOOL OFF)
+set(GEN_FILES OFF CACHE BOOL "mbedtls: use pre-generated source files")
 
 # Make sure mbedtls finds the same Python interpreter as IDF uses
 idf_build_get_property(python PYTHON)

--- a/components/mbedtls/esp_tee/esp_tee_mbedtls.cmake
+++ b/components/mbedtls/esp_tee/esp_tee_mbedtls.cmake
@@ -19,11 +19,11 @@ idf_component_register(SRCS "${srcs}"
                        PRIV_REQUIRES "${priv_requires}")
 
 # Only build mbedtls libraries
-set(ENABLE_TESTING CACHE BOOL OFF)
-set(ENABLE_PROGRAMS CACHE BOOL OFF)
+set(ENABLE_TESTING OFF CACHE BOOL "mbedtls: enable testing")
+set(ENABLE_PROGRAMS OFF CACHE BOOL "mbedtls: enable programs")
 
 # Use pre-generated source files in mbedtls repository
-set(GEN_FILES CACHE BOOL OFF)
+set(GEN_FILES OFF CACHE BOOL "mbedtls: use pre-generated source files")
 
 # Needed to for include_next includes to work from within mbedtls
 include_directories("${COMPONENT_DIR}/port/include")


### PR DESCRIPTION
In `components/mbedtls/CMakeLists.txt` and `components/mbedtls/esp_tee/esp_tee_mbedtls.cmake`, the CACHE variables `ENABLE_TESTING`, `ENABLE_PROGRAMS`, and `GEN_FILES` were set incorrectly.

The syntax for setting cache variables is actually `set(<variable> <value> CACHE <type> <docstring>)` and not `set(<variable> CACHE <type> <value>)`.

The previous code silently set the variables to the empty string.

Upstream PR: https://github.com/espressif/esp-idf/pull/18121

## Testcase

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Before the change:

- Build an example esp-idf project
- See the empty `ENABLE_TESTING:BOOL=` in `build/CMakeCache.txt`

After the change:

- Build an example esp-idf project
- See the correct `ENABLE_TESTING:BOOL=OFF` in `build/CMakeCache.txt`

Building before and after the change also results in the same binaries except for build time and esp-idf version string.