### PR TITLE
fix(esp_netif/lwip): Fix losing DNS when another interface starts

### DIFF
--- a/components/esp_netif/lwip/esp_netif_lwip.c
+++ b/components/esp_netif/lwip/esp_netif_lwip.c
@@ -1601,7 +1601,7 @@ static esp_err_t esp_netif_dhcpc_stop_api(esp_netif_api_msg_t *msg)
 
 esp_err_t esp_netif_dhcpc_stop(esp_netif_t *esp_netif) _RUN_IN_LWIP_TASK_IF_SUPPORTED(esp_netif_dhcpc_stop_api, esp_netif, NULL)
 
-static void dns_clear_servers(bool keep_fallback)
+static void dns_clear_servers_with_netif(esp_netif_t *esp_netif, bool keep_fallback)
 {
     u8_t numdns = 0;
 
@@ -1610,7 +1610,14 @@ static void dns_clear_servers(bool keep_fallback)
             continue;
         }
 
+#ifdef CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF
+        store_dnsserver_info(esp_netif->lwip_netif, numdns, NULL);
+        if (esp_netif == s_last_default_esp_netif) {
+            dns_setserver(numdns, NULL);
+        }
+#else
         dns_setserver(numdns, NULL);
+#endif
     }
 }
 
@@ -1634,7 +1641,7 @@ static esp_err_t esp_netif_dhcpc_start_api(esp_netif_api_msg_t *msg)
     esp_netif_reset_ip_info(esp_netif);
 
 #if LWIP_DNS
-    dns_clear_servers(true);
+    dns_clear_servers_with_netif(esp_netif, true);
 #endif
 
     if (p_netif != NULL) {
@@ -2002,7 +2009,7 @@ static esp_err_t esp_netif_set_ip_info_api(esp_netif_api_msg_t *msg)
             return ESP_ERR_ESP_NETIF_DHCP_NOT_STOPPED;
         }
 #if LWIP_DNS /* don't build if not configured for use in lwipopts.h */
-        dns_clear_servers(true);
+        dns_clear_servers_with_netif(esp_netif, true);
 #endif
     }
 


### PR DESCRIPTION
When an LWIP interface is started, currently the global DNS list is cleared, regardless of which interface is currently set as the default interface.

When `CONFIG_ESP_NETIF_SET_DNS_PER_DEFAULT_NETIF` is enabled, the DNS should only be cleared if the interface is currently set as default, otherwise DNS resolving via the default interface may stop working until the next change in connection state occurs.

Upstream PR: https://github.com/espressif/esp-idf/pull/18141

# Testing

Tested via our internal codebase. After the change, the global DNS is no longer cleared intermittently when a non-default interface is (re-)started.